### PR TITLE
Corrigido erro ao duplicar nome de prédio

### DIFF
--- a/app/Http/Requests/PredioRequest.php
+++ b/app/Http/Requests/PredioRequest.php
@@ -24,7 +24,7 @@ class PredioRequest extends FormRequest
     public function rules()
     {
         return [
-            'nome' => 'required',
+            'nome' => 'required|unique:predios',
         ];
     }
 

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -3,20 +3,24 @@
 @section('content')
     @auth
         <h4>Escolha um prédio</h4>
-
+        <table class="table table-sm table-striped table-hover datatable">
+        <thead>
+            <tr>
+                <th>Prédios</th>
+            </tr>
+        </thead>
         <form>
             @csrf
             <div class="form-group">
-                <label for="predio">Prédio </label>
-                <select class="form-control w-50" id="predio">
-                    @forelse ($predios as $predio)
-                        <option onclick="location.href = 'acessos/create/{{ $predio->id }}';">{{ $predio->nome }}</option>
-                    @empty
-                        <option>Nenhum prédio cadastrado</option>
-                    @endforelse
-                </select>
+                <label for="predio"> </label>
+                @foreach ($predios as $predio)
+                <tr>
+                    <td><a href="acessos/create/{{ $predio->id }}" name ="predio-nome">{{ $predio->nome }}</a></td>
+                </tr>
+        @endforeach
               </div>
         </form>
+        </table>
     @else
         <div class="row">
             <div class="col-sm">

--- a/resources/views/predios/index.blade.php
+++ b/resources/views/predios/index.blade.php
@@ -15,11 +15,11 @@
             <tr>
                 <td><a href="acessos/create/{{ $predio->id }}">{{ $predio->nome }}</a></td>
 
-                <td><button onclick="location.href = 'predios/{{ $predio->id }}/edit';" type="button" class="btn btn-success mb-2"> Editar </button>
+                <td><button onclick="location.href = 'predios/{{ $predio->id }}/edit';" type="button" class="btn btn-success mb-2" name="Editar"> Editar </button>
                 <form method="POST" action="/predios/{{$predio->id}}">
                     @csrf
                     @method('DELETE')    
-                    <button type="submit" class="btn btn-success mb-2"> Delete</button>
+                    <button type="submit" class="btn btn-success mb-2" name="Delete"> Delete</button>
                     
                 </form></td>
             </tr>


### PR DESCRIPTION
Anteriormente, ao cadastrar um prédio com o nome de um prédio já existente um erro aparecia. Para corrigir este cenário adicionei a chave "unique:predios" na linha 27

Fix #23