### PR TITLE
Alteração no redirecionamento da URL após criação

### DIFF
--- a/app/Http/Controllers/AcessoController.php
+++ b/app/Http/Controllers/AcessoController.php
@@ -82,10 +82,10 @@ class AcessoController extends Controller
             } else {
                 $status = 'danger';
             }
-            $rota = (config('acesso.rotaAposRegistroAcesso') == 'create') ? "acessos/create/{$acesso->predio}" : "acessos/{$acesso->id}";
+            $rota = (config('acesso.rotaAposRegistroAcesso') == 'create') ? "acessos/create/{$acesso->predio_id}" : "acessos/{$acesso->id}";
             $request->session()->flash('alert-success', "Acesso registrado com sucesso!");
         } else {
-            $rota = "acessos/create/{$predio}";
+            $rota = "acessos/create/{$acesso->predio_id}";
             $request->session()->flash('alert-danger', 'Pessoa não encontrada nos sistemas USP!');
         }
 


### PR DESCRIPTION
O redirecionamento estava apontando para o objeto prédio inteiro, invés de apontar para o id do prédio. No cenário de configuração view este apontamento não retornava nenhum erro, entretanto para a configuração create um erro aparecia.

Fix #25